### PR TITLE
Increase the Kafka cluster creation timeout to 24 hours

### DIFF
--- a/ccloud/resource_kafka_cluster.go
+++ b/ccloud/resource_kafka_cluster.go
@@ -173,7 +173,7 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		Pending:      []string{"Pending"},
 		Target:       []string{"Ready"},
 		Refresh:      clusterReady(c, d.Id(), accountID, key.Key, key.Secret),
-		Timeout:      1800 * time.Second,
+		Timeout:      24 * 60 * 60 * time.Second,
 		Delay:        3 * time.Second,
 		PollInterval: 5 * time.Second,
 		MinTimeout:   20 * time.Second,


### PR DESCRIPTION
In the documentation, Confluent states that dedicated Kafka clusters can take up to 24 hours to provision on AWS.
This change increases the timeout to 24 hours.